### PR TITLE
feat: add bilibili utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ AstrBot 插件：模拟虚拟角色 **八奈见杏菜** 的行为轨迹。
 
 - `/track <json>` 运行一次推演循环。指令参数为行为状态 JSON，格式
   参考 `soulmaker.behavior_tracker.BehaviorState`。
+- `/bili_rank [rid]` 查看 B 站排行榜（可选分区 `rid`）。
+- `/bili_random` 随机推荐一个热门视频。
+- `/bili_search <关键词>` 搜索指定视频。
+- `/bili_partition <rid>` 查看指定分区的最新视频。
 
 ## 依赖
 

--- a/main.py
+++ b/main.py
@@ -14,6 +14,12 @@ from soulmaker.behavior_tracker import (
     HistoryEntry,
     Memory,
 )
+from soulmaker.bilibili_api import (
+    get_ranking,
+    get_random_video,
+    search_videos,
+    search_partition,
+)
 
 
 @register("soulmaker", "YourName", "行为轨迹生成插件", "0.1.0")
@@ -44,3 +50,48 @@ class SoulmakerPlugin(Star):
             }
         }
         yield event.plain_result(json.dumps(result, ensure_ascii=False))
+
+    @filter.command("bili_rank")
+    async def bili_rank(self, event: AstrMessageEvent, rid: str = "0"):
+        """View bilibili ranking for a partition."""
+
+        videos = await get_ranking(int(rid))
+        lines = [
+            f"{idx + 1}. {v.get('title')} https://www.bilibili.com/video/{v.get('bvid')}"
+            for idx, v in enumerate(videos[:10])
+        ]
+        yield event.plain_result("\n".join(lines))
+
+    @filter.command("bili_random")
+    async def bili_random(self, event: AstrMessageEvent):
+        """Get a random popular video from bilibili."""
+
+        video = await get_random_video()
+        if not video:
+            yield event.plain_result("未获取到视频")
+            return
+        yield event.plain_result(
+            f"{video.get('title')} https://www.bilibili.com/video/{video.get('bvid')}"
+        )
+
+    @filter.command("bili_search")
+    async def bili_search(self, event: AstrMessageEvent, keyword: str):
+        """Search bilibili videos by keyword."""
+
+        videos = await search_videos(keyword)
+        lines = [
+            f"{v.get('title')} https://www.bilibili.com/video/{v.get('bvid', v.get('id'))}"
+            for v in videos[:5]
+        ]
+        yield event.plain_result("\n".join(lines) or "无结果")
+
+    @filter.command("bili_partition")
+    async def bili_partition(self, event: AstrMessageEvent, rid: str):
+        """Search videos from a specific partition."""
+
+        videos = await search_partition(int(rid))
+        lines = [
+            f"{v.get('title')} https://www.bilibili.com/video/{v.get('bvid')}"
+            for v in videos[:5]
+        ]
+        yield event.plain_result("\n".join(lines) or "无结果")

--- a/soulmaker/bilibili_api.py
+++ b/soulmaker/bilibili_api.py
@@ -1,0 +1,65 @@
+import random
+from typing import List, Dict, Any, Optional
+
+import httpx
+
+BASE_URL = "https://api.bilibili.com"
+
+
+async def get_ranking(rid: int = 0, ranking_type: str = "all") -> List[Dict[str, Any]]:
+    """Fetch ranking list from bilibili.
+
+    Parameters
+    ----------
+    rid: int
+        Partition ID. 0 means overall.
+    ranking_type: str
+        Ranking type, e.g. 'all', 'origin', 'rookie'.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        List of ranking entries.
+    """
+    url = f"{BASE_URL}/x/web-interface/ranking/v2"
+    params = {"rid": rid, "type": ranking_type}
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("data", {}).get("list", [])
+
+
+async def get_random_video() -> Optional[Dict[str, Any]]:
+    """Fetch a random video from popular list."""
+    url = f"{BASE_URL}/x/web-interface/popular"
+    params = {"ps": 20, "pn": 1}
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        items = resp.json().get("data", {}).get("list", [])
+    if not items:
+        return None
+    return random.choice(items)
+
+
+async def search_videos(keyword: str, page: int = 1) -> List[Dict[str, Any]]:
+    """Search videos by keyword."""
+    url = f"{BASE_URL}/x/web-interface/search/type"
+    params = {"search_type": "video", "keyword": keyword, "page": page}
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("data", {}).get("result", [])
+
+
+async def search_partition(rid: int, page: int = 1, ps: int = 20) -> List[Dict[str, Any]]:
+    """Fetch videos from a specific partition."""
+    url = f"{BASE_URL}/x/web-interface/newlist"
+    params = {"rid": rid, "pn": page, "ps": ps}
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+    return data.get("data", {}).get("archives", [])


### PR DESCRIPTION
## Summary
- add asynchronous helpers for Bilibili ranking, search, and partition browsing
- expose Bilibili commands in plugin entry for ranking, random videos, keyword search, and partition retrieval
- document new commands in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68941bfecd6c8330b964d6b5e343c1f0